### PR TITLE
 Add support for process limiting severityLevel to the CodeValidator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.sitenv.vocabulary</groupId>
 	<artifactId>codevalidator-api</artifactId>
-	<version>1.0.21-SNAPSHOT</version>
+	<version>1.0.21</version>
 	<name>Code Validator API</name>
 	<url>http://www.sitenv.org</url>
 

--- a/src/main/java/org/sitenv/vocabularies/configuration/ConfiguredValidationResultSeverityLevel.java
+++ b/src/main/java/org/sitenv/vocabularies/configuration/ConfiguredValidationResultSeverityLevel.java
@@ -33,7 +33,7 @@ public class ConfiguredValidationResultSeverityLevel {
 
 	public SeverityLevel getSeverityLevelConversion() {
 		return convertConfiguredValidationResultSeverityLevelToSeverityLevel(
-				ConfiguredSeverityLevel.valueOf(codeSeverityLevel));
+				ConfiguredSeverityLevel.valueOf(codeSeverityLevel.toUpperCase()));
 	}
 	
 	private SeverityLevel convertConfiguredValidationResultSeverityLevelToSeverityLevel(

--- a/src/main/java/org/sitenv/vocabularies/configuration/ConfiguredValidationResultSeverityLevel.java
+++ b/src/main/java/org/sitenv/vocabularies/configuration/ConfiguredValidationResultSeverityLevel.java
@@ -5,6 +5,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.sitenv.vocabularies.constants.VocabularyConstants.ConfiguredSeverityLevel;
+import org.sitenv.vocabularies.constants.VocabularyConstants.SeverityLevel;
+
 /**
  * Created by Brian on 2/10/2016.
  */
@@ -26,6 +29,25 @@ public class ConfiguredValidationResultSeverityLevel {
 
     public void setCodeSeverityLevel(String codeSeverityLevel) {
         this.codeSeverityLevel = codeSeverityLevel;
+    }
+
+	public SeverityLevel getSeverityLevelConversion() {
+		return convertConfiguredValidationResultSeverityLevelToSeverityLevel(
+				ConfiguredSeverityLevel.valueOf(codeSeverityLevel));
+	}
+	
+	private SeverityLevel convertConfiguredValidationResultSeverityLevelToSeverityLevel(
+			ConfiguredSeverityLevel configuredSeverityLevel) {		
+		switch (configuredSeverityLevel) {
+		case MAY:
+			return SeverityLevel.INFO;		
+		case SHOULD:
+			return SeverityLevel.WARNING;			
+		case SHALL:
+			return SeverityLevel.ERROR;
+		default:
+			return SeverityLevel.INFO; 
+		}    	
     }
 }
 

--- a/src/main/java/org/sitenv/vocabularies/constants/VocabularyConstants.java
+++ b/src/main/java/org/sitenv/vocabularies/constants/VocabularyConstants.java
@@ -60,4 +60,8 @@ public class VocabularyConstants {
 	public enum SeverityLevel {
 		INFO, WARNING, ERROR
 	}
+	
+	public enum ConfiguredSeverityLevel {
+		MAY, SHOULD, SHALL
+	}
 }

--- a/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
@@ -81,8 +81,13 @@ public class VocabularyValidationService {
     
 	public List<VocabularyValidationResult> validate(InputStream stream, String vocabularyConfig)
 			throws IOException, SAXException {
+		return validate(stream, vocabularyConfig, SeverityLevel.INFO);
+    }
+	
+	public List<VocabularyValidationResult> validate(InputStream stream, String vocabularyConfig, SeverityLevel severityLevel)
+			throws IOException, SAXException {
         Document doc = documentBuilder.parse(stream);
-        return this.validate(doc, vocabularyConfig);
+        return this.validate(doc, vocabularyConfig, severityLevel);
     }
 
 	public List<VocabularyValidationResult> validate(Document doc) {

--- a/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
+++ b/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
@@ -1,5 +1,6 @@
 package org.sitenv.vocabularies.test.other;
-import static org.sitenv.vocabularies.test.other.ValidationLogger.*;
+
+import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
 
 import java.io.IOException;
 import java.net.URI;
@@ -18,6 +19,7 @@ import org.sitenv.vocabularies.configuration.ConfiguredExpression;
 import org.sitenv.vocabularies.configuration.ConfiguredValidationResultSeverityLevel;
 import org.sitenv.vocabularies.configuration.ConfiguredValidator;
 import org.sitenv.vocabularies.constants.VocabularyConstants;
+import org.sitenv.vocabularies.constants.VocabularyConstants.SeverityLevel;
 import org.sitenv.vocabularies.validation.NodeValidatorFactory;
 import org.sitenv.vocabularies.validation.dto.GlobalCodeValidatorResults;
 import org.sitenv.vocabularies.validation.dto.VocabularyValidationResult;
@@ -37,14 +39,14 @@ public class VocabularyValidationTester {
 	XPathFactory xPathFactory;
 	NodeValidatorFactory vocabularyValidatorFactory;
 	ServletContext context;
-    GlobalCodeValidatorResults globalCodeValidatorResults;
-    
+	GlobalCodeValidatorResults globalCodeValidatorResults;
+
 	@Before
-	public void initialize() {		
+	public void initialize() {
 		codeValidatorConfig = new CodeValidatorApiConfiguration();
 		intializeVocabularyValidationServiceFields();
 	}
-	
+
 	private void intializeVocabularyValidationServiceFields() {
 		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
 		try {
@@ -59,20 +61,21 @@ public class VocabularyValidationTester {
 	}
 
 	public void setupInitParameters(boolean isFileBasedConfig) {
-		if(isFileBasedConfig) {
+		if (isFileBasedConfig) {
 			println("Setting up for file based config...");
 			final String resourcePath = "src/test/resources";
-	        context.setInitParameter("vocabulary.localCodeRepositoryDir", "C:/Programming/SITE/code_repository");
-	        context.setInitParameter("vocabulary.localValueSetRepositoryDir", "C:/Programming/SITE/valueset_repository");
-	        context.setInitParameter("referenceccda.isDynamicVocab", "true");
-	        context.setInitParameter("referenceccda.configFolder", resourcePath);
-	        context.setInitParameter("content.scenariosDir", "C:/Programming/SITE/scenarios");
+			context.setInitParameter("vocabulary.localCodeRepositoryDir", "C:/Programming/SITE/code_repository");
+			context.setInitParameter("vocabulary.localValueSetRepositoryDir",
+					"C:/Programming/SITE/valueset_repository");
+			context.setInitParameter("referenceccda.isDynamicVocab", "true");
+			context.setInitParameter("referenceccda.configFolder", resourcePath);
+			context.setInitParameter("content.scenariosDir", "C:/Programming/SITE/scenarios");
 		} else {
 			println("Setting up for programmable config...");
-			context.setInitParameter("referenceccda.isDynamicVocab", "false");	
+			context.setInitParameter("referenceccda.isDynamicVocab", "false");
 		}
 	}
-		
+
 	public void programmaticallyConfigureRequiredNodeValidator(ConfiguredValidationResultSeverityLevel severity,
 			String requiredNodeName, String validationMessage, String configuredXpathExpression) {
 		ConfiguredValidator configuredValidator = new ConfiguredValidator();
@@ -97,17 +100,23 @@ public class VocabularyValidationTester {
 		ReflectionTestUtils.setField(vocabularyValidationService, "vocabularyValidatorFactory",
 				vocabularyValidatorFactory);
 		ReflectionTestUtils.setField(vocabularyValidationService, "context", context);
-		ReflectionTestUtils.setField(vocabularyValidationService, "globalCodeValidatorResults", globalCodeValidatorResults);
+		ReflectionTestUtils.setField(vocabularyValidationService, "globalCodeValidatorResults",
+				globalCodeValidatorResults);
 	}
 
 	public List<VocabularyValidationResult> testVocabularyValidator(URI filePath) {
 		return testVocabularyValidator(filePath, VocabularyConstants.Config.DEFAULT);
 	}
-	
+
 	public List<VocabularyValidationResult> testVocabularyValidator(URI filePath, String vocabularyConfig) {
+		return testVocabularyValidator(filePath, vocabularyConfig, SeverityLevel.INFO);
+	}
+
+	public List<VocabularyValidationResult> testVocabularyValidator(URI filePath, String vocabularyConfig,
+			SeverityLevel severityLevel) {
 		List<VocabularyValidationResult> results = new ArrayList<>();
 		try {
-			results = vocabularyValidationService.validate(filePath.toString(), vocabularyConfig);
+			results = vocabularyValidationService.validate(filePath.toString(), vocabularyConfig, severityLevel);
 			println("results.size(): " + results.size());
 			for (VocabularyValidationResult result : results) {
 				println(result.toString());
@@ -140,20 +149,20 @@ public class VocabularyValidationTester {
 		}
 		return isMatching;
 	}
-	
+
 	public GlobalCodeValidatorResults getGlobalCodeValidatorResults() {
 		return globalCodeValidatorResults;
 	}
-	
+
 	/**
 	 * 
-	 * @return a testable version of VocabularyValidationService. *Note*:
-	 *         This is NULL without initialize(), setupInitParameters(x),
+	 * @return a testable version of VocabularyValidationService. *Note*: This
+	 *         is NULL without initialize(), setupInitParameters(x),
 	 *         injectDependencies(); i.e. it must be setup the same as any other
 	 *         test
 	 */
 	public VocabularyValidationService getVocabularyValidationService() {
 		return vocabularyValidationService;
-	}	
+	}
 
 }

--- a/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
+++ b/src/test/java/org/sitenv/vocabularies/test/other/VocabularyValidationTester.java
@@ -75,11 +75,11 @@ public class VocabularyValidationTester {
 			context.setInitParameter("referenceccda.isDynamicVocab", "false");
 		}
 	}
-
-	public void programmaticallyConfigureRequiredNodeValidator(ConfiguredValidationResultSeverityLevel severity,
+	
+	public static ConfiguredExpression createConfiguredExpression(String validatorName, ConfiguredValidationResultSeverityLevel severity,
 			String requiredNodeName, String validationMessage, String configuredXpathExpression) {
 		ConfiguredValidator configuredValidator = new ConfiguredValidator();
-		configuredValidator.setName("RequiredNodeValidator");
+		configuredValidator.setName(validatorName);
 		configuredValidator.setConfiguredValidationResultSeverityLevel(severity);
 		configuredValidator.setRequiredNodeName(requiredNodeName);
 		configuredValidator.setValidationMessage(validationMessage);
@@ -87,8 +87,20 @@ public class VocabularyValidationTester {
 		configuredExpression
 				.setConfiguredValidators(new ArrayList<ConfiguredValidator>(Arrays.asList(configuredValidator)));
 		configuredExpression.setConfiguredXpathExpression(configuredXpathExpression);
+		return configuredExpression;
+	}
+
+	public void programmaticallyConfigureRequiredNodeValidator(ConfiguredValidationResultSeverityLevel severity,
+			String requiredNodeName, String validationMessage, String configuredXpathExpression) {		
+		ConfiguredExpression configuredExpression = createConfiguredExpression("RequiredNodeValidator", severity,
+				requiredNodeName, validationMessage, configuredXpathExpression);		
 		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
 		vocabularyValidationConfigurations.addAll(Arrays.asList(configuredExpression));
+	}
+	
+	public void addConfiguredExpressionsToVocabularyValidationConfigurations (List<ConfiguredExpression> configuredExpressions) {
+		vocabularyValidationConfigurations = new ArrayList<ConfiguredExpression>();
+		vocabularyValidationConfigurations.addAll(configuredExpressions);
 	}
 
 	public void injectDependencies() {

--- a/src/test/java/org/sitenv/vocabularies/test/tests/VocabularyValidationServiceTest.java
+++ b/src/test/java/org/sitenv/vocabularies/test/tests/VocabularyValidationServiceTest.java
@@ -1,5 +1,7 @@
 package org.sitenv.vocabularies.test.tests;
-import static org.sitenv.vocabularies.test.other.ValidationLogger.*;
+
+import static org.sitenv.vocabularies.test.other.ValidationLogger.logResults;
+import static org.sitenv.vocabularies.test.other.ValidationLogger.println;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -10,6 +12,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.sitenv.vocabularies.configuration.ConfiguredValidationResultSeverityLevel;
+import org.sitenv.vocabularies.constants.VocabularyConstants.ConfiguredSeverityLevel;
+import org.sitenv.vocabularies.constants.VocabularyConstants.SeverityLevel;
 import org.sitenv.vocabularies.test.other.ValidationLogger;
 import org.sitenv.vocabularies.test.other.ValidationTest;
 import org.sitenv.vocabularies.test.other.VocabularyValidationTester;
@@ -18,7 +22,7 @@ import org.sitenv.vocabularies.validation.dto.enums.VocabularyValidationResultLe
 
 public class VocabularyValidationServiceTest extends VocabularyValidationTester implements ValidationTest {
 
-	private static final boolean LOG_RESULTS_TO_CONSOLE = false;
+	private static final boolean LOG_RESULTS_TO_CONSOLE = true;
 	private static final int MISSING_UNIT_ATTRIBUTE = 0, HAS_UNIT_ATTRIBUTE = 1;
 	private static URI[] CCDA_FILES = new URI[0];
 	static {
@@ -30,29 +34,28 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 			if (logResults)
 				e.printStackTrace();
 		}
-		
+
 		BasicConfigurator.configure();
 	}
 
 	private static final String ASSERT_MSG_NO_VOCABULARY_ISSUE_BUT_SHOULD = "A vocabulary issue does not exist when it should";
 	private static final String ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT = "A vocabulary issue exists but it should not exist";
 	private static final String ASSERT_MSG_SEVERITY_OR_MESSAGE_DOES_NOT_MATCH_BUT_SHOULD = "Severity or message does not match but should";
-	private static final String ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT = "The specified severity with message exists but should not";	
+	private static final String ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT = "The specified severity with message exists but should not";
 
 	@Override
 	@Before
 	public void initializeLogResultsToConsoleValue() {
-		ValidationLogger.logResults = LOG_RESULTS_TO_CONSOLE;		
+		ValidationLogger.logResults = LOG_RESULTS_TO_CONSOLE;
 	}
-	
+
 	@Test
 	public void requiredNodeValidatorMissingAttributeTest() {
-		/* XML example - expect error for NO @unit
-		<observation classCode="OBS" moodCode="EVN">
-			...
-			<value xsi:type="PQ" value="1.015"/>
-			...
-		</observation> */	
+		/*
+		 * XML example - expect error for NO @unit <observation classCode="OBS"
+		 * moodCode="EVN"> ... <value xsi:type="PQ" value="1.015"/> ...
+		 * </observation>
+		 */
 		String validationMessage = "If Observation/value is a physical quantity (xsi:type=\"PQ\"), "
 				+ "the unit of measure SHALL be selected from ValueSet UnitsOfMeasureCaseSensitive 2.16.840.1.113883.1.11.12839 DYNAMIC "
 				+ "(CONF:1198-31484).";
@@ -72,62 +75,59 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 		Assert.assertTrue(ASSERT_MSG_SEVERITY_OR_MESSAGE_DOES_NOT_MATCH_BUT_SHOULD,
 				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHALL, expectedMessage));
 
-		/* XML example - expect no error as has @unit
-		<observation classCode="OBS" moodCode="EVN">
-			...
-			<value xsi:type="PQ" value="1.015" unit="someUnit"/>
-			...
-		</observation> */
+		/*
+		 * XML example - expect no error as has @unit <observation
+		 * classCode="OBS" moodCode="EVN"> ... <value xsi:type="PQ"
+		 * value="1.015" unit="someUnit"/> ... </observation>
+		 */
 		results = testVocabularyValidator(CCDA_FILES[HAS_UNIT_ATTRIBUTE]);
-		
+
 		Assert.assertFalse(ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT, hasVocabularyIssue(results));
 		Assert.assertFalse(ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT,
 				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHALL, expectedMessage));
 	}
-	
+
 	@Test
-	public void requiredNodeValidatorMissingAttributeFileBasedConfigTest() {		
+	public void requiredNodeValidatorMissingAttributeFileBasedConfigTest() {
 		setupInitParameters(true);
 		injectDependencies();
-		
-		/* XML example - expect error for NO @unit
-		<observation classCode="OBS" moodCode="EVN">
-			...
-			<value xsi:type="PQ" value="1.015"/>
-			...
-		</observation> */
+
+		/*
+		 * XML example - expect error for NO @unit <observation classCode="OBS"
+		 * moodCode="EVN"> ... <value xsi:type="PQ" value="1.015"/> ...
+		 * </observation>
+		 */
 		String expectedMessage = "The node '@unit' does not exist at the expected path "
 				+ "/ClinicalDocument[1]/component[1]/structuredBody[1]/component[10]/section[1]/entry[1]/organizer[1]/component[3]/observation[1]/value[1] "
-				+ "but is required as per the specification: " 
+				+ "but is required as per the specification: "
 				+ "If Observation/value is a physical quantity (xsi:type=\"PQ\"), the unit of measure SHALL be selected from "
 				+ "ValueSet UnitsOfMeasureCaseSensitive 2.16.840.1.113883.1.11.12839 DYNAMIC (CONF:1198-31484).";
 		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE],
 				"requiredNodeValidatorMissingAttributeConfig");
 
-		Assert.assertTrue(ASSERT_MSG_NO_VOCABULARY_ISSUE_BUT_SHOULD, hasVocabularyIssue(results));		
+		Assert.assertTrue(ASSERT_MSG_NO_VOCABULARY_ISSUE_BUT_SHOULD, hasVocabularyIssue(results));
 		Assert.assertTrue(ASSERT_MSG_SEVERITY_OR_MESSAGE_DOES_NOT_MATCH_BUT_SHOULD,
 				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHALL, expectedMessage));
 
-		/* XML example - expect no error as has @unit
-		<observation classCode="OBS" moodCode="EVN">
-			...
-			<value xsi:type="PQ" value="1.015" unit="someUnit"/>
-			...
-		</observation> */
-		results = testVocabularyValidator(CCDA_FILES[HAS_UNIT_ATTRIBUTE], "requiredNodeValidatorMissingAttributeConfig");
-		
+		/*
+		 * XML example - expect no error as has @unit <observation
+		 * classCode="OBS" moodCode="EVN"> ... <value xsi:type="PQ"
+		 * value="1.015" unit="someUnit"/> ... </observation>
+		 */
+		results = testVocabularyValidator(CCDA_FILES[HAS_UNIT_ATTRIBUTE],
+				"requiredNodeValidatorMissingAttributeConfig");
+
 		Assert.assertFalse(ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT, hasVocabularyIssue(results));
 		Assert.assertFalse(ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT,
 				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHALL, expectedMessage));
-	}	
+	}
 
 	@Test
 	public void requiredNodeValidatorMissingElementTest() {
-		/* XML example - expect warning for NO <prefix>
-		<name>
-			<given>James</given>
-			<family>Madison</family>
-		</name> */
+		/*
+		 * XML example - expect warning for NO <prefix> <name>
+		 * <given>James</given> <family>Madison</family> </name>
+		 */
 		String validationMessage = "informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)";
 		String configuredXpathExpression = "//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name";
 		ConfiguredValidationResultSeverityLevel severity = new ConfiguredValidationResultSeverityLevel("SHOULD");
@@ -142,80 +142,170 @@ public class VocabularyValidationServiceTest extends VocabularyValidationTester 
 				+ "/ClinicalDocument[1]/informant[2]/relatedEntity[1]/relatedPerson[1]/name[1] "
 				+ "but is required as per the specification: " + validationMessage;
 		Assert.assertTrue(ASSERT_MSG_SEVERITY_OR_MESSAGE_DOES_NOT_MATCH_BUT_SHOULD,
-				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));		
+				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));
 
-		/* XML example - expect no warning as has <prefix>
-		<name>
-			<prefix>Dr</prefix>
-			<given>Albert</given>
-			<family>Davis</family>
-		</name> */
+		/*
+		 * XML example - expect no warning as has <prefix> <name>
+		 * <prefix>Dr</prefix> <given>Albert</given> <family>Davis</family>
+		 * </name>
+		 */
 		validationMessage = "informationRecipient/intendedRecipient/informationRecipient/name SHOULD contain a prefix element (not a real rule - just a test)";
 		configuredXpathExpression = "//v3:informationRecipient/v3:intendedRecipient/v3:informationRecipient/v3:name";
 		programmaticallyConfigureRequiredNodeValidator(severity, element, validationMessage, configuredXpathExpression);
 		injectDependencies();
-		
+
 		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE]);
-		
+
 		Assert.assertFalse(ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT, hasVocabularyIssue(results));
 		expectedMessage = "The node 'v3:prefix' does not exist at the expected path "
 				+ "/ClinicalDocument[1]/informationRecipient[1]/intendedRecipient[1]/informationRecipient[1]/name[1] "
-				+ "but is required as per the specification: " + validationMessage;		
+				+ "but is required as per the specification: " + validationMessage;
 		Assert.assertFalse(ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT,
-				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));		
+				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));
 	}
-	
+
 	@Test
 	public void requiredNodeValidatorMissingElementFileBasedConfigTest() {
 		setupInitParameters(true);
 		injectDependencies();
-		
-		/* XML example - expect warning for NO <prefix>
-		<name>
-			<given>James</given>
-			<family>Madison</family>
-		</name> */
+
+		/*
+		 * XML example - expect warning for NO <prefix> <name>
+		 * <given>James</given> <family>Madison</family> </name>
+		 */
 		String expectedMessage = "The node 'v3:prefix' does not exist at the expected path "
 				+ "/ClinicalDocument[1]/informant[2]/relatedEntity[1]/relatedPerson[1]/name[1] "
-				+ "but is required as per the specification: " 
-				+ "informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)";		
-		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "requiredNodeValidatorMissingElementConfig");
+				+ "but is required as per the specification: "
+				+ "informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)";
+		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE],
+				"requiredNodeValidatorMissingElementConfig");
 
 		Assert.assertTrue(ASSERT_MSG_NO_VOCABULARY_ISSUE_BUT_SHOULD, hasVocabularyIssue(results));
 		Assert.assertTrue(ASSERT_MSG_SEVERITY_OR_MESSAGE_DOES_NOT_MATCH_BUT_SHOULD,
-				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));		
+				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));
 
-		/* XML example - expect no warning as has <prefix>
-		<name>
-			<prefix>Dr</prefix>
-			<given>Albert</given>
-			<family>Davis</family>
-		</name> */
+		/*
+		 * XML example - expect no warning as has <prefix> <name>
+		 * <prefix>Dr</prefix> <given>Albert</given> <family>Davis</family>
+		 * </name>
+		 */
 		expectedMessage = "The node 'v3:prefix' does not exist at the expected path "
 				+ "/ClinicalDocument[1]/informationRecipient[1]/intendedRecipient[1]/informationRecipient[1]/name[1] "
 				+ "but is required as per the specification: "
 				+ "informationRecipient/intendedRecipient/informationRecipient/name SHOULD contain a prefix element (not a real rule - just a test)";
-		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "requiredNodeValidatorMissingElementConfig");
-		
+		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE],
+				"requiredNodeValidatorMissingElementConfig");
+
 		// ensure there are no more warnings than the previous tests result
 		Assert.assertFalse(ASSERT_MSG_HAS_VOCABULARY_ISSUE_BUT_SHOULD_NOT, results.size() > 1);
 		Assert.assertFalse(ASSERT_MSG_SEVERITY_WITH_MESSAGE_MATCHES_BUT_SHOULD_NOT,
-				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));		
+				isResultMatchingExpectedResult(results, VocabularyValidationResultLevel.SHOULD, expectedMessage));
 	}
-	
+
 	@Test
-	public void VocabularyValidationConfigurationsCountTest() {
+	public void vocabularyValidationConfigurationsCountTest() {
 		setupInitParameters(true);
 		injectDependencies();
-			
+
 		testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "requiredNodeValidatorMissingElementConfig");
-		
-		final int expectedConfigCount = 2;
+		countTestHelper(2);
+	}
+
+	private void countTestHelper(final int expectedConfigCount) {
 		final int configCount = getGlobalCodeValidatorResults().getVocabularyValidationConfigurationsCount();
 		println("vocabularyValidationConfigurationsCount: " + configCount);
 		Assert.assertTrue("VocabularyValidationConfigurationsCount should be more than 0", configCount > 0);
-		Assert.assertTrue("VocabularyValidationConfigurationsCount should equal to " + expectedConfigCount + " as per the content of "
-				+ "requiredNodeValidatorMissingElementConfig", configCount == expectedConfigCount);		
+		Assert.assertTrue(
+				"VocabularyValidationConfigurationsCount should equal to " + expectedConfigCount
+						+ " as per the content of " + "requiredNodeValidatorMissingElementConfig",
+				configCount == expectedConfigCount);
 	}
 
+	@Test
+	public void severityLevelCountTest() {
+		setupInitParameters(true);
+		injectDependencies();
+
+		testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "severityLevelCountTestConfig", SeverityLevel.INFO);
+		countTestHelper(3);
+
+		testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "severityLevelCountTestConfig",
+				SeverityLevel.WARNING);
+		countTestHelper(2);
+
+		testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "severityLevelCountTestConfig",
+				SeverityLevel.ERROR);
+		countTestHelper(1);
+	}
+
+	private SeverityCount severityLevelLimitTestHelper(List<VocabularyValidationResult> results) {
+		SeverityCount severityCount = new SeverityCount();
+		for (VocabularyValidationResult result : results) {
+			if (result.getVocabularyValidationResultLevel().name().equals(ConfiguredSeverityLevel.SHALL.name())) {
+				severityCount.incrementShallCount();
+			} else if (result.getVocabularyValidationResultLevel().name()
+					.equals(ConfiguredSeverityLevel.SHOULD.name())) {
+				severityCount.incrementShouldCount();
+			} else if (result.getVocabularyValidationResultLevel().name().equals(ConfiguredSeverityLevel.MAY.name())) {
+				severityCount.incrementMayCount();
+			}
+		}
+		return severityCount;
+	}
+
+	@Test
+	public void severityLevelLimitTest() {
+		setupInitParameters(true);
+		injectDependencies();
+
+		List<VocabularyValidationResult> results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE],
+				"severityLevelLimitTestConfig", SeverityLevel.INFO);
+		SeverityCount severityCount = severityLevelLimitTestHelper(results);
+		Assert.assertTrue("The severitylevel was set to INFO yet not all types of results were returned",
+				severityCount.getShallCount() > 0 && severityCount.getShouldCount() > 0
+						&& severityCount.getMayCount() > 0);
+
+		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "severityLevelLimitTestConfig",
+				SeverityLevel.WARNING);
+		severityCount = severityLevelLimitTestHelper(results);
+		Assert.assertTrue("The severitylevel was set to WARNING yet info messages were processed and returned",
+				severityCount.getShallCount() > 0 && severityCount.getShouldCount() > 0
+						&& severityCount.getMayCount() < 1);
+
+		results = testVocabularyValidator(CCDA_FILES[MISSING_UNIT_ATTRIBUTE], "severityLevelLimitTestConfig",
+				SeverityLevel.ERROR);
+		severityCount = severityLevelLimitTestHelper(results);
+		Assert.assertTrue(
+				"The severitylevel was set to ERROR yet info and/or warning messages were processed and returned",
+				severityCount.getShallCount() > 0 && severityCount.getShouldCount() < 1
+						&& severityCount.getMayCount() < 1);
+	}
+}
+
+class SeverityCount {
+	int shallCount = 0, shouldCount = 0, mayCount = 0;
+
+	public int getShallCount() {
+		return shallCount;
+	}
+
+	public void incrementShallCount() {
+		this.shallCount++;
+	}
+
+	public int getShouldCount() {
+		return shouldCount;
+	}
+
+	public void incrementShouldCount() {
+		this.shouldCount++;
+	}
+
+	public int getMayCount() {
+		return mayCount;
+	}
+
+	public void incrementMayCount() {
+		this.mayCount++;
+	}
 }

--- a/src/test/resources/severityLevelCountTestConfig.xml
+++ b/src/test/resources/severityLevelCountTestConfig.xml
@@ -1,0 +1,36 @@
+<configurations>
+
+    <expression xpathExpression="//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name">
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>MAY</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name MAY contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+	</expression>
+	
+    <expression xpathExpression="//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name">
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHOULD</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+	</expression>
+	
+    <expression xpathExpression="//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name">
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHALL</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHALL contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+	</expression>		
+  
+</configurations>

--- a/src/test/resources/severityLevelLimitTestConfig.xml
+++ b/src/test/resources/severityLevelLimitTestConfig.xml
@@ -1,0 +1,84 @@
+<configurations>
+
+    <expression xpathExpression="//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name">
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>MAY</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name MAY contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>MAY</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name MAY contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>MAY</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name MAY contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>				
+	</expression>		
+	
+    <expression xpathExpression="//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name">
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHOULD</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHOULD</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHOULD</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHOULD contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>				
+	</expression>
+	
+    <expression xpathExpression="//v3:informant/v3:relatedEntity/v3:relatedPerson/v3:name">
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHALL</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHALL contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHALL</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHALL contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>
+		<validator>
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHALL</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <requiredNodeName>v3:prefix</requiredNodeName>
+			<validationMessage>informant/relatedEntity/relatedPerson/name SHALL contain a prefix element (not a real rule - just a test)</validationMessage>
+		</validator>				
+	</expression>		
+  
+</configurations>


### PR DESCRIPTION
The Reference C-CDA Validator API and static UI in local instantiations now support limiting MDHT Conformance and Vocabulary Validation results via their severity (Content limiting is coming soon). This has the potential to offer significant performance gains for users only interested in specific types of results, expecially on larger or issue-prone files. To use the feature, either use the static UI, or, send body form-data key:severityLevel and value:ERROR, WARNING, or INFO. Please note that selecting INFO will return all results, WARNING will return warnings and errors, and ERROR will return errors only.